### PR TITLE
Add ID cookies to persist user identity

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,18 +1,24 @@
 // Import dependencies
 const path = require('path');
 const express = require('express');
+const cookieParser = require('cookie-parser');
 
 // Add .env variables to environment
 require('dotenv').config();
 
-// Import DB object
-const db = require('./db/db.js')
+// Import local dependencies
+const db = require('./db/db.js');
+const idCookiesMiddleware = require('./util/idCookies');
 
 // If environment defines a port, use it; if not, default to the standard 3000
 const PORT = process.env.PORT || 3000;
 
 // Create express app object
 const app = express();
+
+// Attach middleware
+app.use(cookieParser()); // Parse cookie headers
+app.use(idCookiesMiddleware); // Attach ID cookies when needed
 
 // Set up express to serve static files from the /static directory
 app.use('/static', express.static(path.join(__dirname, 'static')));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1523,6 +1523,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
+    "cookie-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -4434,6 +4443,12 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -4807,6 +4822,11 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -5643,9 +5663,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
     },
     "v8-to-istanbul": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
   },
   "homepage": "https://github.com/travisbartholome/cosc4351-final-project#readme",
   "dependencies": {
+    "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",
     "ejs": "^3.0.2",
     "express": "^4.17.1",
     "pg": "^8.0.2",
     "pg-hstore": "^2.3.3",
-    "sequelize": "^5.21.6"
+    "sequelize": "^5.21.6",
+    "uuid": "^7.0.3"
   },
   "devDependencies": {
     "jest": "^25.3.0",

--- a/util/__tests__/idCookies.test.js
+++ b/util/__tests__/idCookies.test.js
@@ -1,0 +1,36 @@
+const idCookies = require('../idCookies');
+
+describe('idCookies', () => {
+  it('should call res.cookie to attach a new id cookie if none is present', () => {
+    const req = {
+      cookies: {},
+    };
+    const res = {
+      cookie: jest.fn(),
+    };
+    const next = jest.fn();
+
+    idCookies(req, res, next);
+
+    expect(res.cookie).toHaveBeenCalled();
+    expect(res.cookie.mock.calls[0][0]).toBe('id'); // Name of the new cookie should be 'id' 
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should not attach a new cookie if an id cookie is present', () => {
+    const req = {
+      cookies: {
+        id: 'asdf',
+      },
+    };
+    const res = {
+      cookie: jest.fn(),
+    };
+    const next = jest.fn();
+
+    idCookies(req, res, next);
+
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/util/idCookies.js
+++ b/util/idCookies.js
@@ -1,0 +1,19 @@
+const uuid = require('uuid');
+
+// Express middleware function that sets an ID cookie
+// if the current user doesn't already have one
+module.exports = (req, res, next) => {
+  if (!req.cookies.id) {
+    const id = uuid.v4(); // Random UUID
+    const maxAge = 3600 * 24 * 180 * 1000; // Cookie lasts 180 days (value in milliseconds)
+    
+    // Create new ID cookie
+    res.cookie('id', id, {
+      maxAge: maxAge,
+      sameSite: 'Strict',
+    });
+  }
+
+  // Pass the Express call down to the next handler
+  next();
+}


### PR DESCRIPTION
This cookie will be used to identify users who are using or returning to the site. Will allow us to maintain things like the user's cart - we can associate cart items in our database with a specific user.