### PR TITLE
Add cart item quantity

### DIFF
--- a/db/dbFunctions.js
+++ b/db/dbFunctions.js
@@ -67,10 +67,16 @@ const getUserCart = userIdCookie => {
       return totalPrice + (currentItem.price * currentItem.quantity);
     }, 0);
 
+    // Find the total number of items in the cart
+    const totalItems = products.reduce((itemCount, product) => {
+      return itemCount + product.quantity;
+    }, 0);
+
     // Return the new cart object
     return ({
       products,
       total,
+      totalItems,
     });
   });
 };

--- a/db/dbFunctions.js
+++ b/db/dbFunctions.js
@@ -7,6 +7,17 @@ const getAllProducts = () => {
   });
 };
 
+// Find one cart item row with the specified cart and product numbers
+const getCartItem = (cartId, productId) => {
+  return db.CartItem.findOne({
+    where: {
+      cart_id: cartId,
+      product_id: productId,
+    },
+    raw: true
+  });
+};
+
 const increaseQuantityByOne = (cart_id, product_id) => {
   return db.CartItem.update(
     { quantity: db.sequelize.literal('quantity + 1') }, 
@@ -36,6 +47,7 @@ const getUserCart = userIdCookie => {
     const products = items.map(item => ({
       id: item['product.id'],
       price: item['product.price'],
+      quantity: item['quantity'],
       description: item['product.description'],
       name: item['product.name'],
       image: item['product.image'],
@@ -56,32 +68,44 @@ const getUserCart = userIdCookie => {
 
 // Add an item to the current user's cart
 // Returns the new cart for that user along with some query metadata
-const addItemToCart = (productId, userIdCookie) => {
+const addItemToCart = async (productId, userIdCookie) => {
   // If the user doesn't already have a cart, we should create a new one for them
-  return db.Cart.findOrCreate({
+  const [cartData, cartCreated] = await db.Cart.findOrCreate({
     where: {
       session_key: userIdCookie,
     },
-  })
-  .then(([cartData, cartCreated]) => {
-    // Insert the newly added item into cart_items
+  });
+
+  const cartId = cartData.getDataValue('cart_id');
+
+  // Figure out if the user already had one of this item in their cart
+  // (Not possible if the cart was just created)
+  const existingCartItem = cartCreated ? false : await getCartItem(cartId, productId);
+
+  if (existingCartItem) {
+    // If so, just update the quantity column for that item in the cart
+    const cartItem = await increaseQuantityByOne(cartId, productId);
+  } else {
+    // Otherwise, insert the newly added item into cart_items
     // Associate it with the found (or newly created) cart
-    return db.CartItem.create({
-      cart_id: cartData.getDataValue('cart_id'),
+    const cartItem = await db.CartItem.create({
+      cart_id: cartId,
       product_id: productId,
     });
-  })
-  .then((cartItem) => {
-    return getUserCart(userIdCookie).then(userCart => ({
-      cart: userCart,
-      cart_id: cartItem.getDataValue('cart_id'),
-      session_key: userIdCookie,
-    }));
+  }
+
+  const userCart = await getUserCart(userIdCookie);
+  
+  return ({
+    cart: userCart,
+    cart_id: cartId,
+    session_key: userIdCookie,
   });
 };
 
 module.exports = {
   getAllProducts,
+  getCartItem,
   increaseQuantityByOne,
   getUserCart,
   addItemToCart,

--- a/db/dbFunctions.js
+++ b/db/dbFunctions.js
@@ -64,7 +64,7 @@ const getUserCart = userIdCookie => {
 
     // Sum up the price of all the cart items
     const total = products.reduce((totalPrice, currentItem) => {
-      return totalPrice + currentItem.price;
+      return totalPrice + (currentItem.price * currentItem.quantity);
     }, 0);
 
     // Return the new cart object

--- a/routers/__tests__/api.test.js
+++ b/routers/__tests__/api.test.js
@@ -27,9 +27,31 @@ describe('api', () => {
       .send({ productId: 42 })
       .expect(200)
       .then(response => {
-        const {productId, idCookie } = response.body;
+        const { productId, idCookie } = response.body;
         expect(productId).toEqual(42);
         expect(idCookie).toEqual('test-id-cookie');
       });
+  });
+
+  it('should respond correctly on POST to /api/cart/remove', () => {
+    // Mock out removeItemFromCart
+    dbFunctions.removeItemFromCart = (productId, idCookie) => Promise.resolve({
+      cart: {
+        // Making sure these values get passed through
+        productId,
+        idCookie,
+      },
+    });
+
+    return request(app)
+      .post('/api/cart/remove')
+      .set('Cookie', ['id=test-cart-remove'])
+      .send({ productId: 42 })
+      .expect(200)
+      .then(response => {
+        const { productId, idCookie } = response.body;
+        expect(productId).toEqual(42);
+        expect(idCookie).toEqual('test-cart-remove');
+      })
   });
 });

--- a/routers/api.js
+++ b/routers/api.js
@@ -24,4 +24,15 @@ api.post('/cart/add', (req, res) => {
     .then(({ cart }) => res.json(cart));
 });
 
+api.post('/cart/remove', (req, res) => {
+  const { productId } = req.body;
+  const userIdCookie = req.cookies.id;
+
+  // Remove the specified item from the user's cart
+  // Return the newe cart state as the POST response
+  return dbFunctions
+    .removeItemFromCart(productId, userIdCookie)
+    .then(({ cart }) => res.json(cart));
+});
+
 module.exports = api;

--- a/tests/__snapshots__/app.test.js.snap
+++ b/tests/__snapshots__/app.test.js.snap
@@ -3,9 +3,9 @@
 exports[`App views should render the cart page successfully 1`] = `
 Object {
   "connection": "close",
-  "content-length": "2906",
+  "content-length": "2907",
   "content-type": "text/html; charset=utf-8",
-  "etag": "W/\\"b5a-bhtoC0bTWPJbYDVnRMU+/GiorZ0\\"",
+  "etag": "W/\\"b5b-YvOp4m+X65v8T8TsXa7Mo626OSw\\"",
   "x-powered-by": "Express",
 }
 `;
@@ -70,7 +70,7 @@ exports[`App views should render the cart page successfully 2`] = `
   <div class=\\"content-container\\">
     <div class=\\"row\\">
     </div>
-    Total: 6
+    Total: 12
     <br>
     <button type=\\"button\\" class=\\"btn btn-secondary\\"><a href=\\"/checkout\\">Checkout</a></button>
   </div>

--- a/tests/__snapshots__/app.test.js.snap
+++ b/tests/__snapshots__/app.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "connection": "close",
   "content-length": "2907",
   "content-type": "text/html; charset=utf-8",
-  "etag": "W/\\"b5b-YvOp4m+X65v8T8TsXa7Mo626OSw\\"",
+  "etag": "W/\\"b5b-6eywA9V9hQmqZJVeybuqU1ktbLE\\"",
   "x-powered-by": "Express",
 }
 `;
@@ -54,7 +54,7 @@ exports[`App views should render the cart page successfully 2`] = `
         <a class=\\"nav-link\\" href=\\"/cart\\">
             <span class=\\"fas fa-shopping-cart\\"></span>
             Cart
-            <span class=\\"badge badge-primary\\" id=\\"badge-cart-size\\">1</span>
+            <span class=\\"badge badge-primary\\" id=\\"badge-cart-size\\">2</span>
         </a>
       </li> 
       <li class=\\"nav-item\\">
@@ -90,7 +90,7 @@ Object {
   "connection": "close",
   "content-length": "9764",
   "content-type": "text/html; charset=utf-8",
-  "etag": "W/\\"2624-3RXJ4iDeP1zBzLGGS3o6VwErdNE\\"",
+  "etag": "W/\\"2624-p3FvD+/l+Ez5H8kEGRMOF8QTOAM\\"",
   "x-powered-by": "Express",
 }
 `;
@@ -138,7 +138,7 @@ exports[`App views should render the checkout page successfully 2`] = `
         <a class=\\"nav-link\\" href=\\"/cart\\">
             <span class=\\"fas fa-shopping-cart\\"></span>
             Cart
-            <span class=\\"badge badge-primary\\" id=\\"badge-cart-size\\">1</span>
+            <span class=\\"badge badge-primary\\" id=\\"badge-cart-size\\">2</span>
         </a>
       </li> 
       <li class=\\"nav-item\\">
@@ -313,9 +313,9 @@ exports[`App views should render the checkout page successfully 2`] = `
 exports[`App views should render the root/browse page successfully 1`] = `
 Object {
   "connection": "close",
-  "content-length": "7766",
+  "content-length": "7847",
   "content-type": "text/html; charset=utf-8",
-  "etag": "W/\\"1e56-44I1TTnX706mjj9VmquWu4pgQqA\\"",
+  "etag": "W/\\"1ea7-nWUU3w5uAPVaSXjFDkjo1+YmviQ\\"",
   "x-powered-by": "Express",
 }
 `;
@@ -364,7 +364,7 @@ exports[`App views should render the root/browse page successfully 2`] = `
         <a class=\\"nav-link\\" href=\\"/cart\\">
             <span class=\\"fas fa-shopping-cart\\"></span>
             Cart
-            <span class=\\"badge badge-primary\\" id=\\"badge-cart-size\\">1</span>
+            <span class=\\"badge badge-primary\\" id=\\"badge-cart-size\\">2</span>
         </a>
       </li> 
       <li class=\\"nav-item\\">
@@ -516,7 +516,9 @@ exports[`App views should render the root/browse page successfully 2`] = `
         // Handle response data, or do nothing
         console.log(data);
         console.log(status);
-        $('#badge-cart-size').text(data.products.length);
+        $('#badge-cart-size').text(data.products.reduce((total, product) => {
+          return total + product.quantity;
+        }, 0));
       });
     }
   </script>

--- a/tests/__snapshots__/db.test.js.snap
+++ b/tests/__snapshots__/db.test.js.snap
@@ -36,6 +36,7 @@ Object {
       "image": "product4.jpg",
       "name": "Product 4",
       "price": 6,
+      "quantity": 1,
     },
   ],
   "total": 6,

--- a/tests/__snapshots__/db.test.js.snap
+++ b/tests/__snapshots__/db.test.js.snap
@@ -27,8 +27,6 @@ Object {
 }
 `;
 
-exports[`dbFunctions getUserCart should return an object with the correct cart structure 1`] = `12`;
-
 exports[`dbFunctions getUserCart should return cart items associated with a given user 1`] = `
 Object {
   "products": Array [
@@ -42,5 +40,6 @@ Object {
     },
   ],
   "total": 12,
+  "totalItems": 2,
 }
 `;

--- a/tests/__snapshots__/db.test.js.snap
+++ b/tests/__snapshots__/db.test.js.snap
@@ -27,6 +27,8 @@ Object {
 }
 `;
 
+exports[`dbFunctions getUserCart should return an object with the correct cart structure 1`] = `12`;
+
 exports[`dbFunctions getUserCart should return cart items associated with a given user 1`] = `
 Object {
   "products": Array [
@@ -36,9 +38,9 @@ Object {
       "image": "product4.jpg",
       "name": "Product 4",
       "price": 6,
-      "quantity": 1,
+      "quantity": 2,
     },
   ],
-  "total": 6,
+  "total": 12,
 }
 `;

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -70,6 +70,7 @@ describe('dbFunctions', () => {
 
         // Cart should have a `total` property
         expect(cart).toHaveProperty('total');
+        expect(cart.total).toMatchSnapshot();
       });
     });
   });

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -70,7 +70,8 @@ describe('dbFunctions', () => {
 
         // Cart should have a `total` property
         expect(cart).toHaveProperty('total');
-        expect(cart.total).toMatchSnapshot();
+        // Should have a `totalItems` property
+        expect(cart).toHaveProperty('totalItems');
       });
     });
   });

--- a/views/browse.ejs
+++ b/views/browse.ejs
@@ -37,7 +37,9 @@
         // Handle response data, or do nothing
         console.log(data);
         console.log(status);
-        $('#badge-cart-size').text(data.products.length);
+        $('#badge-cart-size').text(data.products.reduce((total, product) => {
+          return total + product.quantity;
+        }, 0));
       });
     }
   </script>

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -20,7 +20,7 @@
         <a class="nav-link" href="/cart">
             <span class="fas fa-shopping-cart"></span>
             Cart
-            <span class="badge badge-primary" id="badge-cart-size"><%= cart.products.length %></span>
+            <span class="badge badge-primary" id="badge-cart-size"><%= cart.totalItems || 0 %></span>
         </a>
       </li> 
       <li class="nav-item">


### PR DESCRIPTION
Adds the ability to have multiple of the same item in the cart via a `quantity` field. Supports this change in existing backend functions. Also adds an API endpoint at /api/cart/remove that will allow us to remove an item from the cart in the same way that /api/cart/add lets us add an item to the cart.

I've put a bit more information about what the API requests and responses should look like in the Google doc (in an "API Reference" section).