### PR TITLE
Address validation styling

### DIFF
--- a/static/styles/checkout.css
+++ b/static/styles/checkout.css
@@ -9,6 +9,7 @@
 }
 
 .address-feedback {
+  margin-left: 15px;
   margin-bottom: 5px;
   padding: 5px 10px;
   border-radius: 5px;

--- a/static/styles/checkout.css
+++ b/static/styles/checkout.css
@@ -1,0 +1,16 @@
+#address-feedback-incorrect {
+  border-color: #d60000;
+  background: #ff7a7a;
+}
+
+#address-feedback-correct {
+  border-color: green;
+  background: lightgreen;
+}
+
+.address-feedback {
+  margin-bottom: 5px;
+  padding: 5px 10px;
+  border-radius: 5px;
+  border: 1px solid;
+}

--- a/tests/__snapshots__/app.test.js.snap
+++ b/tests/__snapshots__/app.test.js.snap
@@ -396,9 +396,9 @@ exports[`App views should render the cart page successfully 2`] = `
 exports[`App views should render the checkout page successfully 1`] = `
 Object {
   "connection": "close",
-  "content-length": "12089",
+  "content-length": "12537",
   "content-type": "text/html; charset=utf-8",
-  "etag": "W/\\"2f39-bS7ZE6JomWmdxmjWjz4BmeVY/DI\\"",
+  "etag": "W/\\"30f9-CyuvBATvttfH46YUqjs02gfQhUk\\"",
   "x-powered-by": "Express",
 }
 `;
@@ -420,10 +420,11 @@ exports[`App views should render the checkout page successfully 2`] = `
 <link rel=\\"stylesheet\\" href=\\"https://use.fontawesome.com/releases/v5.7.0/css/all.css\\" integrity=\\"sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ\\" crossorigin=\\"anonymous\\">
 <link rel=\\"stylesheet\\" href=\\"/static/styles/header.css\\" />
 <link rel=\\"stylesheet\\" href=\\"/static/styles/global.css\\" />
+    <link rel=\\"stylesheet\\" href=\\"/static/styles/checkout.css\\" />
   </head>
   <body class=\\"bg-light\\">
     <header>
-        <!-- views/header.ejs -->
+      <!-- views/header.ejs -->
 <!-- creates inverted (black) navigation bar w/ top that is fixed-->
 <nav class=\\"navbar navbar-expand-md navbar-dark unique-color-dark fixed-top\\">
     <!-- Brand/logo -->
@@ -556,13 +557,17 @@ exports[`App views should render the checkout page successfully 2`] = `
                   Zip code required.
                 </div>
               </div>
-              <div id=\\"address-feedback-correct\\" style=\\"display:none\\">
-                Address verified!
+            </div>
+
+            <div class=\\"row\\">
+              <div class=\\"col-md-4 address-feedback d-none\\" id=\\"address-feedback-correct\\">
+                <span>Address verified!</span>
               </div>
-              <div id=\\"address-feedback-incorrect\\" style=\\"display:none\\">
-                Address incorrect! Please verify and try again. 
+              <div class=\\"col-md-4 address-feedback d-none\\" id=\\"address-feedback-incorrect\\">
+                <span>Address invalid! Please correct it and try again.</span>
               </div>
             </div>
+
             <h4 class=\\"mb-3\\">Payment</h4>
             <div class=\\"d-block my-3\\">
               <div class=\\"custom-control custom-radio\\">
@@ -640,13 +645,17 @@ exports[`App views should render the checkout page successfully 2`] = `
             setTimeout(function() {
               $('#address-form').submit();
             }, 1000);
-            $('#address-feedback-correct').css('display','block');
-            $('#address-feedback-incorrect').css('display','none');
+            $('#address-feedback-correct').addClass('d-block');
+            $('#address-feedback-incorrect').addClass('d-none');
+            $('#address-feedback-correct').removeClass('d-none');
+            $('#address-feedback-incorrect').removeClass('d-block');
           }
           else {
             // Show address validation was incorrect
-            $('#address-feedback-correct').css('display','none');
-            $('#address-feedback-incorrect').css('display','block');
+            $('#address-feedback-correct').addClass('d-none');
+            $('#address-feedback-incorrect').addClass('d-block');
+            $('#address-feedback-correct').removeClass('d-block');
+            $('#address-feedback-incorrect').removeClass('d-none');
           }
           console.log(data);
         }
@@ -669,9 +678,9 @@ exports[`App views should render the checkout page successfully 2`] = `
 exports[`App views should render the order summary page successfully 1`] = `
 Object {
   "connection": "close",
-  "content-length": "5259",
+  "content-length": "5348",
   "content-type": "text/html; charset=utf-8",
-  "etag": "W/\\"148b-Em5ZORuc6qMYhKb7K63nftr23G0\\"",
+  "etag": "W/\\"14e4-moi8wRr0yCqSo0Uj+bi3g1jksSg\\"",
   "x-powered-by": "Express",
 }
 `;

--- a/tests/__snapshots__/app.test.js.snap
+++ b/tests/__snapshots__/app.test.js.snap
@@ -396,9 +396,9 @@ exports[`App views should render the cart page successfully 2`] = `
 exports[`App views should render the checkout page successfully 1`] = `
 Object {
   "connection": "close",
-  "content-length": "12537",
+  "content-length": "12253",
   "content-type": "text/html; charset=utf-8",
-  "etag": "W/\\"30f9-CyuvBATvttfH46YUqjs02gfQhUk\\"",
+  "etag": "W/\\"2fdd-TSj1Ww3WztojgIQ7/Y8SEnMm3u0\\"",
   "x-powered-by": "Express",
 }
 `;
@@ -577,10 +577,6 @@ exports[`App views should render the checkout page successfully 2`] = `
               <div class=\\"custom-control custom-radio\\">
                 <input id=\\"debit\\" value=\\"debit\\" name=\\"paymentMethod\\" type=\\"radio\\" class=\\"custom-control-input\\" required>
                 <label class=\\"custom-control-label\\" for=\\"debit\\">Debit card</label>
-              </div>
-              <div class=\\"custom-control custom-radio\\">
-                <input id=\\"paypal\\" value=\\"paypal\\" name=\\"paymentMethod\\" type=\\"radio\\" class=\\"custom-control-input\\" required>
-                <label class=\\"custom-control-label\\" for=\\"paypal\\">Paypal</label>
               </div>
             </div>
             <div class=\\"row\\">
@@ -960,9 +956,9 @@ exports[`App views should render the order summary page successfully if no ID co
 exports[`App views should render the root/home page successfully 1`] = `
 Object {
   "connection": "close",
-  "content-length": "3100",
+  "content-length": "3180",
   "content-type": "text/html; charset=utf-8",
-  "etag": "W/\\"c1c-hLALIcgFbrKIFE1UvmdZ0Hv3poU\\"",
+  "etag": "W/\\"c6c-TmoEbmD+D+K1aUXIOlfIMoCAC+M\\"",
   "x-powered-by": "Express",
 }
 `;
@@ -1031,6 +1027,7 @@ exports[`App views should render the root/home page successfully 2`] = `
     <span class =\\"fas fa-glasses fa-4x\\"></span> 
     <p class=\\"lead\\"><strong>Put some swagger in your stride</strong></p>
     </div>
+    <a href=\\"/browse\\" class=\\"btn btn-secondary btn-lg\\">Browse our products</a>
   </div>
   <footer class=\\"container-fluid text-center\\">
     

--- a/views/checkout.ejs
+++ b/views/checkout.ejs
@@ -127,10 +127,6 @@
                 <input id="debit" value="debit" name="paymentMethod" type="radio" class="custom-control-input" required>
                 <label class="custom-control-label" for="debit">Debit card</label>
               </div>
-              <div class="custom-control custom-radio">
-                <input id="paypal" value="paypal" name="paymentMethod" type="radio" class="custom-control-input" required>
-                <label class="custom-control-label" for="paypal">Paypal</label>
-              </div>
             </div>
             <div class="row">
               <div class="col-md-6 mb-3">

--- a/views/checkout.ejs
+++ b/views/checkout.ejs
@@ -2,10 +2,11 @@
 <html>
   <head>
     <%-include ('head.ejs') -%>
+    <link rel="stylesheet" href="/static/styles/checkout.css" />
   </head>
   <body class="bg-light">
     <header>
-        <%-include ('header.ejs') -%>
+      <%-include ('header.ejs') -%>
     </header>
     <div class="container content-container">
       <div class="row">
@@ -105,13 +106,17 @@
                   Zip code required.
                 </div>
               </div>
-              <div id="address-feedback-correct" style="display:none">
-                Address verified!
+            </div>
+
+            <div class="row">
+              <div class="col-md-4 address-feedback d-none" id="address-feedback-correct">
+                <span>Address verified!</span>
               </div>
-              <div id="address-feedback-incorrect" style="display:none">
-                Address incorrect! Please verify and try again. 
+              <div class="col-md-4 address-feedback d-none" id="address-feedback-incorrect">
+                <span>Address invalid! Please correct it and try again.</span>
               </div>
             </div>
+
             <h4 class="mb-3">Payment</h4>
             <div class="d-block my-3">
               <div class="custom-control custom-radio">
@@ -186,13 +191,17 @@
             setTimeout(function() {
               $('#address-form').submit();
             }, 1000);
-            $('#address-feedback-correct').css('display','block');
-            $('#address-feedback-incorrect').css('display','none');
+            $('#address-feedback-correct').addClass('d-block');
+            $('#address-feedback-incorrect').addClass('d-none');
+            $('#address-feedback-correct').removeClass('d-none');
+            $('#address-feedback-incorrect').removeClass('d-block');
           }
           else {
             // Show address validation was incorrect
-            $('#address-feedback-correct').css('display','none');
-            $('#address-feedback-incorrect').css('display','block');
+            $('#address-feedback-correct').addClass('d-none');
+            $('#address-feedback-incorrect').addClass('d-block');
+            $('#address-feedback-correct').removeClass('d-block');
+            $('#address-feedback-incorrect').removeClass('d-none');
           }
           console.log(data);
         }

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -15,6 +15,7 @@
     <span class ="fas fa-glasses fa-4x"></span> 
     <p class="lead"><strong>Put some swagger in your stride</strong></p>
     </div>
+    <a href="/browse" class="btn btn-secondary btn-lg">Browse our products</a>
   </div>
   <footer class="container-fluid text-center">
     <%-include ('footer.ejs') -%>


### PR DESCRIPTION
Adds some styling to the address validation messages. Probably could look better but I'm not sure what else to do with it?

Also took care of a couple of minor items (remove PayPal from payment methods list, add a button on the home page that links to the browse page).

## Screenshots

### Address validation at checkout
Address invalid:
![image](https://user-images.githubusercontent.com/19520765/80192856-6f4ff880-85dd-11ea-9727-be31bda65804.png)

Address valid:
![image](https://user-images.githubusercontent.com/19520765/80192878-7bd45100-85dd-11ea-913f-0706deb5f6e2.png)

### Home page
![image](https://user-images.githubusercontent.com/19520765/80192909-87277c80-85dd-11ea-8920-0bbc7503f85e.png)
